### PR TITLE
Update css to show full text on the signup button on mobile

### DIFF
--- a/classes.html
+++ b/classes.html
@@ -854,7 +854,7 @@
 						<a href="mission.html">Mission</a>
 					</div>
 					<div id="copyright">
-						<p> &#169; 2016-2023. Silicon Valley Youth</p>
+						<p> &#169; 2015-2025. Silicon Valley Youth</p>
 					</div>
 				</div>
 		</div>

--- a/classes/2025/spring/main.html
+++ b/classes/2025/spring/main.html
@@ -186,7 +186,7 @@
             <a href="/mission.html">Mission</a>
           </div>
           <div id="copyright">
-            <p> &#169; 2016-2023. Silicon Valley Youth</p>
+            <p> &#169; 2015-2025. Silicon Valley Youth</p>
           </div>
         </div>
     </div>

--- a/grants.html
+++ b/grants.html
@@ -77,7 +77,7 @@
 			<a href="mission.html">Mission</a>
 		  </div>
 		  <div id="copyright">
-			<p> &#169; 2016-2023. Silicon Valley Youth</p>
+			<p> &#169; 2015-2025. Silicon Valley Youth</p>
 		  </div>
 		</div>
 </div>

--- a/index.html
+++ b/index.html
@@ -80,12 +80,12 @@
       <br>
       <br>
       <br>
-      <a href="classes.html" target=blank style="font-size: 30px; font-weight: bolder">Fall 2025 Class Signups  <i class="fas fa-angle-double-right"></i></a>
+      <a href="classes.html" class="main-cta-button">Fall 2025 Class Signups  <i class="fas fa-angle-double-right"></i></a>
       <!-- <a href="/classes.html" target=blank style="font-size: 30px; font-weight: bolder">Fall 2022 Classes  <i class="fas fa-angle-double-right"></i></a> -->
       <br>
       <br>
       <br>
-      <a href="/grants.html" target=blank style="font-size: 30px; font-weight: bolder">SVY Grants  <i class="fas fa-angle-double-right"></i></a>
+      <a href="grants.html" class="main-cta-button">SVY Grants  <i class="fas fa-angle-double-right"></i></a>
       <br>
       <br>
       </div>
@@ -280,7 +280,7 @@
           <a href="mission.html">Mission</a>
         </div>
         <div id="copyright">
-          <p> &#169; 2016-2023. Silicon Valley Youth</p>
+          <p> &#169; 2015-2025. Silicon Valley Youth</p>
         </div>
        
       </div>

--- a/main.css
+++ b/main.css
@@ -1964,8 +1964,12 @@ transition-duration: 0.5s;}
 	}
 
 	#mainslide a {
-		padding: 8px 18px;
-		font-size: 23px;
+		padding: 8px 15px;
+		font-size: 18px;
+		word-wrap: break-word;
+		text-align: center;
+		display: inline-block;
+		line-height: 1.2;
 	}
 
 	#indexbody {
@@ -2580,16 +2584,51 @@ transition-duration: 0.5s;}
 	}
 
 	#mainslide {
-		width: 80%;
-		padding: 10vh 10%;
+		width: 90%;
+		padding: 8vh 5%;
+		overflow-wrap: break-word;
+		word-break: break-word;
 	}
 
 	#mainslide h1 {
-		font-size: 40px;
+		font-size: 35px;
+		word-wrap: break-word;
+		line-height: 1.1;
 	}
 
 	#mainslide .bold {
-		font-size: 65px;
+		font-size: 50px;
+		word-wrap: break-word;
+		line-height: 1;
+	}
+
+	#mainslide a {
+		padding: 8px 15px !important;
+		font-size: 16px !important;
+		font-weight: bold !important;
+		word-wrap: break-word;
+		text-align: center;
+		display: inline-block;
+		line-height: 1.3;
+		margin: 5px 0;
+		max-width: 90%;
+		box-sizing: border-box;
+		white-space: normal;
+		cursor: pointer;
+		touch-action: manipulation;
+		position: relative;
+		z-index: 100;
+		-webkit-tap-highlight-color: rgba(255,255,0,0.3);
+		pointer-events: auto;
+		-webkit-user-select: none;
+		user-select: none;
+	}
+
+	.main-cta-button {
+		font-size: 16px !important;
+		font-weight: bold !important;
+		text-decoration: none !important;
+		color: white !important;
 	}
 
 	#mainmask {
@@ -3091,6 +3130,8 @@ transition-duration: 0.5s;}
 
 	body, h1, body, div, a, ol, ul, li, h2, p, em, img, button {
 		word-wrap: break-word;
+		overflow-wrap: break-word;
+		word-break: break-word;
 	}
 	/*testing*/
 	.center {

--- a/payment.html
+++ b/payment.html
@@ -144,7 +144,7 @@
             <a href="mission.html">Mission</a>
           </div>
           <div id="copyright">
-            <p> &#169; 2016-2023. Silicon Valley Youth</p>
+            <p> &#169; 2015-2025. Silicon Valley Youth</p>
           </div>
         </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>

--- a/paymentfree.html
+++ b/paymentfree.html
@@ -137,7 +137,7 @@
             <a href="mission.html">Mission</a>
           </div>
           <div id="copyright">
-            <p> &#169; 2016-2023. Silicon Valley Youth</p>
+            <p> &#169; 2015-2025. Silicon Valley Youth</p>
           </div>
         </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>

--- a/wechatgroup.html
+++ b/wechatgroup.html
@@ -71,7 +71,7 @@
             <a href="mission.html">Mission</a>
           </div>
           <div id="copyright">
-            <p> &#169; 2016-2023. Silicon Valley Youth</p>
+            <p> &#169; 2015-2025. Silicon Valley Youth</p>
           </div>
         </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>


### PR DESCRIPTION
Update css to show full text on the signup button on mobile, and also update the copyright year from 2023 to 2025.

After on Mobile:
<img width="1284" height="2778" alt="image" src="https://github.com/user-attachments/assets/fe717aa6-0c89-4c10-807d-63e572897bf0" />

Before on mobile:
<img width="1284" height="2778" alt="image" src="https://github.com/user-attachments/assets/78b7c97c-0c1a-4d31-bc26-e5146afadc04" />

No change on Web other than the copyright year.
<img width="507" height="200" alt="image" src="https://github.com/user-attachments/assets/d92e489f-5893-42bf-a614-023afa52af4e" />
<img width="922" height="815" alt="image" src="https://github.com/user-attachments/assets/7a2c3ace-a64d-4cf6-8ba2-23fabe832f5c" />

